### PR TITLE
Adding reCAPTCHA to Signup Page & Fixed Footer

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -57,6 +57,7 @@
 }
 
 #login form {
+  position: absolute;
   width: 30%;
   background-color: rgba(255, 255, 255, 0.9);
   box-shadow: 1px 1px 10px black;
@@ -126,6 +127,10 @@ main {
 }
 
 footer {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
   background-image: url("/img/papyrus-dark.png");
 }
 

--- a/public/js/signUpValid.js
+++ b/public/js/signUpValid.js
@@ -35,9 +35,15 @@ $(document).ready( function(){
     }
     return isValid;
   }
+  
   $("#submit").on("click", function(event){
     if (!isFormValid()) {
       event.preventDefault();
     }
   });
+
 });
+
+function recaptchaCallback() {
+  $('#submit').removeAttr('disabled');
+};

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -1,4 +1,5 @@
 <%- include('partials/header.ejs') %>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
 <main id="sign-up-grid">
   <form class="container-lg p-5 sg1" method="POST" action="/signup">
@@ -39,9 +40,14 @@
       />
       <span class="errorFdbk" id="pwdConfFdbk"></span>
     </div>
-    <button type="submit" class="btn btn-primary" id="submit">Sign Up</button>
+    <div class="g-recaptcha" data-callback="recaptchaCallback" data-sitekey="6Lfly9IbAAAAAH0rdYb0Gu8QXa6ufx7Fr9N167H0"></div>
+    <br>
+    <button type="submit"  class="btn btn-primary" id="submit">Sign Up</button>
+    <br>
+    <br>
   </form>
   <div class="sg2"></div>
+  <br>
 </main>
 
 <script src="/js/signUpValid.js"></script>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -42,7 +42,7 @@
     </div>
     <div class="g-recaptcha" data-callback="recaptchaCallback" data-sitekey="6Lfly9IbAAAAAH0rdYb0Gu8QXa6ufx7Fr9N167H0"></div>
     <br>
-    <button type="submit"  class="btn btn-primary" id="submit">Sign Up</button>
+    <button type="submit" disabled class="btn btn-primary" id="submit">Sign Up</button>
     <br>
     <br>
   </form>


### PR DESCRIPTION
@raymondshum, 
Added reCAPTCHA to Signup Page, disabled submit button until signup user completes reCAPTCHA and fixed footer on CSS.
~Don't worry about key, it's a public Key for reCAPTCHA

Before Footer:
[https://gyazo.com/a5ed35e7e35062788d0d77fe364b0000](url)
[![Image from Gyazo](https://i.gyazo.com/a5ed35e7e35062788d0d77fe364b0000.png)](https://gyazo.com/a5ed35e7e35062788d0d77fe364b0000)

After Footer with disabled Signup Button and reCAPTCHA:
[https://gyazo.com/1b39b9ccbc9abae1593d7871cdd9cb7a](url)
[![Image from Gyazo](https://i.gyazo.com/1b39b9ccbc9abae1593d7871cdd9cb7a.jpg)](https://gyazo.com/1b39b9ccbc9abae1593d7871cdd9cb7a)

Enabled Signup Button with completing reCAPTCHA:
[https://gyazo.com/177b5e28e316c5ba531b472861e9e1d0](url)
[![Image from Gyazo](https://i.gyazo.com/177b5e28e316c5ba531b472861e9e1d0.png)](https://gyazo.com/177b5e28e316c5ba531b472861e9e1d0)
