### PR TITLE
(security) upgrade tar to 6.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1585,9 +1585,9 @@
       }
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
+      "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",


### PR DESCRIPTION
GitHub detected severe security vulnerability with current version (6.1.0) with issue resolved at 6.1.2. Patch to version 6.1.6.